### PR TITLE
PR || Removes redundant License section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,3 @@ project-root/
 - All responses include a `message` field for clarity.
 
 ---
-
-## License
-MIT


### PR DESCRIPTION
Eliminates the duplicated License section at the end of the README to improve clarity and maintain consistency in the documentation.